### PR TITLE
Remove ligatures and fancy clojure symbols

### DIFF
--- a/config.el
+++ b/config.el
@@ -5,8 +5,7 @@
                                       (git :variables git-gutter-use-fringe t)
                                       github
 
-                                      (clojure :variables
-                                               clojure-enable-fancify-symbols t)
+                                      clojure
                                       emacs-lisp
                                       markdown
                                       org
@@ -33,8 +32,6 @@
 
 ;; TODO: projectile-known-projects
 ;;       add all dirs in ~/workspace
-
-(mac-auto-operator-composition-mode)
 
 (setq dotspacemacs-whitespace-cleanup 'changed)
 


### PR DESCRIPTION
The fancy clojure symbols get in the way of formatting and the ligatures aren't supported without the emacs-mac port
